### PR TITLE
skip deprecated msgs by default

### DIFF
--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -81,6 +81,8 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
   progress_dialog.show();
 
   QString schema_path(std::getenv("BASEDIR"));
+  bool show_deprecated = std::getenv("SHOW_DEPRECATED");
+
   if(schema_path.isNull())
   {
     schema_path = QDir(getpwuid(getuid())->pw_dir).filePath("openpilot"); // fallback to $HOME/openpilot
@@ -129,7 +131,7 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
       } else if (event.has("sendcan")) {
         parser.parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp);
       } else {
-        parser.parseMessageImpl("", event, time_stamp);
+        parser.parseMessageImpl("", event, time_stamp, show_deprecated);
       }
     }
     catch (const kj::Exception& e)

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -16,7 +16,7 @@ bool RlogMessageParser::parseMessage(const MessageRef msg, double time_stamp)
   return false;
 }
 
-bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader value, double time_stamp)
+bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader value, double time_stamp, bool show_deprecated)
 {
 
   PJ::PlotData& _data_series = getSeries(topic_name);
@@ -53,7 +53,7 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
       int i = 0;
       for(auto element : value.as<capnp::DynamicList>())
       {
-        parseMessageImpl(topic_name + '/' + std::to_string(i), element, time_stamp);
+        parseMessageImpl(topic_name + '/' + std::to_string(i), element, time_stamp, show_deprecated);
         i++;
       }
       break;
@@ -75,9 +75,8 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
         {
           std::string name = field.getProto().getName();
 
-          bool show_deprecated = std::getenv("SHOW_DEPRECATED");
           if (show_deprecated || name.find("DEPRECATED") == std::string::npos) {
-            parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp);
+            parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp, show_deprecated);
           }
         }
       }

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -74,7 +74,6 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
         if (structValue.has(field))
         {
           std::string name = field.getProto().getName();
-
           if (show_deprecated || name.find("DEPRECATED") == std::string::npos) {
             parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp, show_deprecated);
           }

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -74,7 +74,11 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
         if (structValue.has(field))
         {
           std::string name = field.getProto().getName();
-          parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp);
+
+          bool show_deprecated = std::getenv("SHOW_DEPRECATED");
+          if (show_deprecated || name.find("DEPRECATED") == std::string::npos) {
+            parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp);
+          }
         }
       }
       break;

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -26,7 +26,7 @@ public:
 
   bool loadDBC(std::string dbc_str);
 
-  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp);
+  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool show_deprecated);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp);
 };


### PR DESCRIPTION
Can be unhidden by setting env variable, `export SHOW_DEPRECATED=`