### PR TITLE
add root Event fields to each sub-struct

### DIFF
--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -126,12 +126,13 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
       }
 
       double time_stamp = (double)event.get("logMonoTime").as<uint64_t>() / 1e9;
+      bool valid = (bool)event.get("valid").as<bool>();
       if (event.has("can")) {
         parser.parseCanMessage("/can", event.get("can").as<capnp::DynamicList>(), time_stamp);
       } else if (event.has("sendcan")) {
         parser.parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp);
       } else {
-        parser.parseMessageImpl("", event, time_stamp, show_deprecated);
+        parser.parseMessageImpl("", event, time_stamp, valid, show_deprecated);
       }
     }
     catch (const kj::Exception& e)

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -131,6 +131,7 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
       } else if (event.has("sendcan")) {
         parser.parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp);
       } else {
+        // second event never changes, to add root fields to all structs
         parser.parseMessageImpl("", event, event, time_stamp, true, show_deprecated);
       }
     }

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -126,13 +126,12 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
       }
 
       double time_stamp = (double)event.get("logMonoTime").as<uint64_t>() / 1e9;
-      bool valid = (bool)event.get("valid").as<bool>();
       if (event.has("can")) {
         parser.parseCanMessage("/can", event.get("can").as<capnp::DynamicList>(), time_stamp);
       } else if (event.has("sendcan")) {
         parser.parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp);
       } else {
-        parser.parseMessageImpl("", event, time_stamp, valid, show_deprecated);
+        parser.parseMessageImpl("", event, time_stamp, show_deprecated);
       }
     }
     catch (const kj::Exception& e)

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -96,7 +96,8 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
   capnp::ParsedSchema schema = schema_parser.parseFromDirectory(fs->getRoot(), kj::Path::parse(schema_path.toStdString()), nullptr);
   capnp::StructSchema event_struct_schema = schema.getNested("Event").asStruct();
 
-  RlogMessageParser parser("", plot_data, std::getenv("SHOW_DEPRECATED"));
+  RlogMessageParser parser("", plot_data);
+  parser.show_deprecated = std::getenv("SHOW_DEPRECATED");
 
   while(amsg.size() > 0)
   {

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -132,7 +132,6 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
         parser.parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp);
       } else {
         parser.parseMessageImpl("", event, time_stamp, true, show_deprecated);
-        break;
       }
     }
     catch (const kj::Exception& e)

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -131,7 +131,8 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
       } else if (event.has("sendcan")) {
         parser.parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp);
       } else {
-        parser.parseMessageImpl("", event, time_stamp, true, show_deprecated);
+        parser.parseMessageImpl("", event, event, time_stamp, true, show_deprecated);
+//        break;
       }
     }
     catch (const kj::Exception& e)

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -126,25 +126,13 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
       }
 
       double time_stamp = (double)event.get("logMonoTime").as<uint64_t>() / 1e9;
-
-//      std::map<capnp::StructSchema::Field, capnp::DynamicValue::Reader> non_unions;
-      vector<capnp::DynamicValue::Reader> test;
-      for (auto field : event.getSchema().getNonUnionFields()) {
-//        std::string name = field.getProto().getName();
-//        qDebug() << "non union:" << name.c_str();
-//        non_unions.insert(std::make_pair(field, event.get(field)));
-        test.push_back(event.get(field));
-//        qDebug() << "output:" << event.get(field);
-//        parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, structValue.get(field), time_stamp, show_deprecated);
-      }
-
       if (event.has("can")) {
         parser.parseCanMessage("/can", event.get("can").as<capnp::DynamicList>(), time_stamp);
       } else if (event.has("sendcan")) {
         parser.parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp);
       } else {
-//        capnp::StructSchema::FieldSubset non_unions = event.getSchema().getNonUnionFields();
-        parser.parseMessageImpl("", event, test, time_stamp, show_deprecated);
+        parser.parseMessageImpl("", event, time_stamp, true, show_deprecated);
+        break;
       }
     }
     catch (const kj::Exception& e)

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -132,7 +132,6 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
         parser.parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp);
       } else {
         parser.parseMessageImpl("", event, event, time_stamp, true, show_deprecated);
-//        break;
       }
     }
     catch (const kj::Exception& e)

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -131,8 +131,7 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
       } else if (event.has("sendcan")) {
         parser.parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp);
       } else {
-        // second event never changes, to add root fields to all structs
-        parser.parseMessageImpl("", event, event, time_stamp, true, show_deprecated);
+        parser.parseMessageImpl("", event, time_stamp, true, show_deprecated);
       }
     }
     catch (const kj::Exception& e)

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -97,7 +97,6 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
   capnp::StructSchema event_struct_schema = schema.getNested("Event").asStruct();
 
   RlogMessageParser parser("", plot_data);
-  parser.show_deprecated = std::getenv("SHOW_DEPRECATED");
 
   while(amsg.size() > 0)
   {

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -126,12 +126,25 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
       }
 
       double time_stamp = (double)event.get("logMonoTime").as<uint64_t>() / 1e9;
+
+//      std::map<capnp::StructSchema::Field, capnp::DynamicValue::Reader> non_unions;
+      vector<capnp::DynamicValue::Reader> test;
+      for (auto field : event.getSchema().getNonUnionFields()) {
+//        std::string name = field.getProto().getName();
+//        qDebug() << "non union:" << name.c_str();
+//        non_unions.insert(std::make_pair(field, event.get(field)));
+        test.push_back(event.get(field));
+//        qDebug() << "output:" << event.get(field);
+//        parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, structValue.get(field), time_stamp, show_deprecated);
+      }
+
       if (event.has("can")) {
         parser.parseCanMessage("/can", event.get("can").as<capnp::DynamicList>(), time_stamp);
       } else if (event.has("sendcan")) {
         parser.parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp);
       } else {
-        parser.parseMessageImpl("", event, time_stamp, show_deprecated);
+//        capnp::StructSchema::FieldSubset non_unions = event.getSchema().getNonUnionFields();
+        parser.parseMessageImpl("", event, test, time_stamp, show_deprecated);
       }
     }
     catch (const kj::Exception& e)

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -101,11 +101,11 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
           const int offset = structValue.getSchema().getProto().getStruct().getDiscriminantCount();
           const bool in_union = field.getProto().getDiscriminantValue() < offset;
 
-          if (!is_root || in_union)  // skip adding root non-union fields
+          if (!is_root || in_union)
           {
             parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp, false);
           }
-          else if (is_root && !in_union)  // adds root fields to each sub-struct
+          else if (is_root && !in_union)
           {
             parseMessageImpl(topic_name + '/' + structName + "/event_" + name, structValue.get(field), time_stamp, false);
           }

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -81,7 +81,6 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
             if (structValue.get(field).getType() != capnp::DynamicValue::STRUCT && is_root) {
               continue;  // skip adding root non-struct fields
             }
-
             std::string name = field.getProto().getName();
             if (show_deprecated || name.find("DEPRECATED") == std::string::npos) {
               parseMessageImpl(topic_name + '/' + name, structValue.get(field), event, time_stamp, false, show_deprecated);

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -71,13 +71,15 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
       auto structValue = value.as<capnp::DynamicStruct>();
       std::string struct_name;
       KJ_IF_MAYBE(e_, structValue.which()) { struct_name = e_->getProto().getName(); }
-      for (auto field : event.getSchema().getNonUnionFields())
+
+      if (!show_deprecated && struct_name.find("DEPRECATED") != std::string::npos) break;
+      for (const auto &field : event.getSchema().getNonUnionFields())
       {  // add root fields to each sub-struct recursively (valid, logMonoTime, etc.)
         std::string name = field.getProto().getName();
         parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, event.get(field), event, time_stamp, false, show_deprecated);
       }
 
-      for (auto field : structValue.getSchema().getFields())
+      for (const auto &field : structValue.getSchema().getFields())
       {
         if (structValue.has(field))
         {

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -69,7 +69,6 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
     case capnp::DynamicValue::STRUCT: 
     {
       auto structValue = value.as<capnp::DynamicStruct>();
-
       if (is_root) {  // add global fields to each sub-struct (valid, logMonoTime, etc.)
         std::string struct_name;
         KJ_IF_MAYBE(e_, structValue.which()) { struct_name = e_->getProto().getName(); }

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -16,7 +16,7 @@ bool RlogMessageParser::parseMessage(const MessageRef msg, double time_stamp)
   return false;
 }
 
-bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader value, double time_stamp, bool show_deprecated)
+bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader value, double time_stamp, bool valid, bool show_deprecated)
 {
 
   PJ::PlotData& _data_series = getSeries(topic_name);
@@ -53,7 +53,7 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
       int i = 0;
       for(auto element : value.as<capnp::DynamicList>())
       {
-        parseMessageImpl(topic_name + '/' + std::to_string(i), element, time_stamp, show_deprecated);
+        parseMessageImpl(topic_name + '/' + std::to_string(i), element, time_stamp, valid, show_deprecated);
         i++;
       }
       break;
@@ -69,13 +69,21 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
     case capnp::DynamicValue::STRUCT: 
     {
       auto structValue = value.as<capnp::DynamicStruct>();
-      for (auto field : structValue.getSchema().getFields()) 
+
+      std::string struct_name;
+      KJ_IF_MAYBE(e_, structValue.which()) {
+        struct_name = e_->getProto().getName();
+      }
+      parseMessageImpl(topic_name + '/' + struct_name + "/log_logMonoTime", time_stamp, time_stamp, valid, show_deprecated);
+      parseMessageImpl(topic_name + '/' + struct_name + "/log_valid", valid, time_stamp, valid, show_deprecated);
+
+      for (auto field : structValue.getSchema().getFields())
       {
         if (structValue.has(field))
         {
           std::string name = field.getProto().getName();
           if (show_deprecated || name.find("DEPRECATED") == std::string::npos) {
-            parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp, show_deprecated);
+            parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp, valid, show_deprecated);
           }
         }
       }

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -81,6 +81,7 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
             if (structValue.get(field).getType() != capnp::DynamicValue::STRUCT && is_root) {
               continue;  // skip adding root non-struct fields
             }
+
             std::string name = field.getProto().getName();
             if (show_deprecated || name.find("DEPRECATED") == std::string::npos) {
               parseMessageImpl(topic_name + '/' + name, structValue.get(field), event, time_stamp, false, show_deprecated);

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -76,7 +76,6 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
       }
 
       if (!show_deprecated && structName.find("DEPRECATED") != std::string::npos) break;
-
       if (is_root)
       {
         for (const auto &field : structValue.getSchema().getNonUnionFields())

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -69,24 +69,29 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
     case capnp::DynamicValue::STRUCT: 
     {
       auto structValue = value.as<capnp::DynamicStruct>();
-        std::string struct_name;
-        KJ_IF_MAYBE(e_, structValue.which()) { struct_name = e_->getProto().getName(); }
-        for (auto field : event.getSchema().getNonUnionFields()) {  // add root fields to each sub-struct recursively (valid, logMonoTime, etc.)
-          std::string name = field.getProto().getName();
-          parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, event.get(field), event, time_stamp, false, show_deprecated);
-        }
+      std::string struct_name;
+      KJ_IF_MAYBE(e_, structValue.which()) { struct_name = e_->getProto().getName(); }
+      for (auto field : event.getSchema().getNonUnionFields())
+      {  // add root fields to each sub-struct recursively (valid, logMonoTime, etc.)
+        std::string name = field.getProto().getName();
+        parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, event.get(field), event, time_stamp, false, show_deprecated);
+      }
 
-        for (auto field : structValue.getSchema().getFields()) {
-          if (structValue.has(field)) {
-            if (structValue.get(field).getType() != capnp::DynamicValue::STRUCT && is_root) {
-              continue;  // skip adding root non-struct fields
-            }
-            std::string name = field.getProto().getName();
-            if (show_deprecated || name.find("DEPRECATED") == std::string::npos) {
-              parseMessageImpl(topic_name + '/' + name, structValue.get(field), event, time_stamp, false, show_deprecated);
-            }
+      for (auto field : structValue.getSchema().getFields())
+      {
+        if (structValue.has(field))
+        {
+          if (structValue.get(field).getType() != capnp::DynamicValue::STRUCT && is_root)
+          {
+            continue;  // skip adding root non-struct fields
+          }
+          std::string name = field.getProto().getName();
+          if (show_deprecated || name.find("DEPRECATED") == std::string::npos)
+          {
+            parseMessageImpl(topic_name + '/' + name, structValue.get(field), event, time_stamp, false, show_deprecated);
           }
         }
+      }
       break;
     }
 

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -91,7 +91,7 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
 
       for (const auto &field : structValue.getSchema().getFields())
       {
-        // skip adding root non-struct fields
+        // skip adding root non-union fields
         if (structValue.has(field) && (!is_root || (structValue.get(field).getType() == capnp::DynamicValue::STRUCT)))
         {
           std::string name = field.getProto().getName();

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -73,10 +73,8 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
         std::string struct_name;
         KJ_IF_MAYBE(e_, structValue.which()) { struct_name = e_->getProto().getName(); }
         for (auto field : structValue.getSchema().getNonUnionFields()) {
-          if (structValue.has(field)) {
-            std::string name = field.getProto().getName();
-            parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, structValue.get(field), time_stamp, false, show_deprecated);
-          }
+          std::string name = field.getProto().getName();
+          parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, structValue.get(field), time_stamp, false, show_deprecated);
         }
       }
 

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -75,7 +75,11 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
         structName = e_->getProto().getName();
       }
 
-      if (!show_deprecated && structName.find("DEPRECATED") != std::string::npos) break;
+      if (!show_deprecated && structName.find("DEPRECATED") != std::string::npos)
+      {
+        break;
+      }
+
       if (is_root)
       {
         for (const auto &field : structValue.getSchema().getNonUnionFields())
@@ -87,12 +91,9 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
 
       for (const auto &field : structValue.getSchema().getFields())
       {
-        if (structValue.has(field))
+        // skip adding root non-struct fields
+        if (structValue.has(field) && (!is_root || (structValue.get(field).getType() == capnp::DynamicValue::STRUCT)))
         {
-          if (structValue.get(field).getType() != capnp::DynamicValue::STRUCT && is_root)
-          {
-            continue;  // skip adding root non-struct fields
-          }
           std::string name = field.getProto().getName();
           if (show_deprecated || name.find("DEPRECATED") == std::string::npos)
           {

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -97,7 +97,7 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
         for (const auto &field : structValue.getSchema().getNonUnionFields())
         {  // add root fields to root struct (valid, logMonoTime, etc.)
           std::string name = field.getProto().getName();
-          parseMessageImpl(topic_name + '/' + structName + "/event_" + name, structValue.get(field), time_stamp, false, show_deprecated);
+          parseMessageImpl(topic_name + '/' + structName + "/event_" + name, structValue.get(field), time_stamp, false);
         }
       }
 

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -16,7 +16,7 @@ bool RlogMessageParser::parseMessage(const MessageRef msg, double time_stamp)
   return false;
 }
 
-bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader value, double time_stamp, bool show_deprecated)
+bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader value, vector<capnp::DynamicValue::Reader> test, double time_stamp, bool show_deprecated)
 {
 
   PJ::PlotData& _data_series = getSeries(topic_name);
@@ -53,7 +53,7 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
       int i = 0;
       for(auto element : value.as<capnp::DynamicList>())
       {
-        parseMessageImpl(topic_name + '/' + std::to_string(i), element, time_stamp, show_deprecated);
+        parseMessageImpl(topic_name + '/' + std::to_string(i), element, test, time_stamp, show_deprecated);
         i++;
       }
       break;
@@ -69,12 +69,32 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
     case capnp::DynamicValue::STRUCT: 
     {
       auto structValue = value.as<capnp::DynamicStruct>();
-
       std::string struct_name;
       KJ_IF_MAYBE(e_, structValue.which()) {
         struct_name = e_->getProto().getName();
       }
-      std::vector<std::string> global_fields {"logMonoTime", "valid"};
+//      std::vector<std::string> global_fields {"logMonoTime", "valid"};
+
+//      for (auto field : non_unions) {
+////        if (structValue.has(field)) {
+////          std::string name = field.first;
+//          std::string name = field.first.getProto().getName();
+//          std::string value = field.second;
+//          qDebug() << "non union:" << name.c_str();
+////          field.getProto().getConst().getValue();
+////          qDebug() << structValue.get(field);
+////          parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, value, non_unions, time_stamp, show_deprecated);
+////        }
+//      }
+//      for (auto field : non_unions) {
+////        if (structValue.has(field)) {
+//          std::string name = field.getProto().getName();
+//          qDebug() << "non union:" << name.c_str();
+//          field.getProto().getConst().getValue();
+////          qDebug() << structValue.get(field);
+//          parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, structValue.get(field), non_unions, time_stamp, show_deprecated);
+////        }
+//      }
 
       for (auto field : structValue.getSchema().getFields())
       {
@@ -82,11 +102,13 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
         if (structValue.has(field))
         {
           if (show_deprecated || name.find("DEPRECATED") == std::string::npos) {
-            if (std::find(global_fields.begin(), global_fields.end(), name) != global_fields.end()) {
-              parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, structValue.get(field), time_stamp, show_deprecated);
-            } else {
-              parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp, show_deprecated);
-            }
+//            if (std::find(global_fields.begin(), global_fields.end(), name) != global_fields.end()) {
+//            if (!structValue.getSchema().getProto().isStruct()) {
+//              qDebug() << "adding" << name.c_str() << "to" << struct_name.c_str();
+//              parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, structValue.get(field), time_stamp, show_deprecated);
+//            } else {
+              parseMessageImpl(topic_name + '/' + name, structValue.get(field), test, time_stamp, show_deprecated);
+//            }
           }
         }
       }

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -76,16 +76,23 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
           std::string name = field.getProto().getName();
           parseMessageImpl(topic_name + '/' + struct_name + "/event_" + name, structValue.get(field), time_stamp, false, show_deprecated);
         }
-      }
 
-      for (auto field : structValue.getSchema().getFields())
-      {
-        if (structValue.has(field))
-        {
-          std::string name = field.getProto().getName();
-          if (show_deprecated || name.find("DEPRECATED") == std::string::npos)
-          {
-            parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp, false, show_deprecated);
+        for (auto field : structValue.getSchema().getUnionFields()) {
+          if (structValue.has(field)) {
+            std::string name = field.getProto().getName();
+            if (show_deprecated || name.find("DEPRECATED") == std::string::npos) {
+              parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp, false, show_deprecated);
+            }
+          }
+        }
+
+      } else {
+        for (auto field : structValue.getSchema().getFields()) {
+          if (structValue.has(field)) {
+            std::string name = field.getProto().getName();
+            if (show_deprecated || name.find("DEPRECATED") == std::string::npos) {
+              parseMessageImpl(topic_name + '/' + name, structValue.get(field), time_stamp, false, show_deprecated);
+            }
           }
         }
       }

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -26,7 +26,7 @@ public:
 
   bool loadDBC(std::string dbc_str);
 
-  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool show_deprecated);
+  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool valid, bool show_deprecated);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp);
 };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -26,7 +26,7 @@ public:
 
   bool loadDBC(std::string dbc_str);
 
-  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool valid, bool show_deprecated);
+  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool show_deprecated);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp);
 };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -26,7 +26,7 @@ public:
 
   bool loadDBC(std::string dbc_str);
 
-  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root, bool show_deprecated);
+  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, capnp::DynamicStruct::Reader event, double timestamp, bool is_root, bool show_deprecated);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp);
 };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -26,7 +26,7 @@ public:
 
   bool loadDBC(std::string dbc_str);
 
-  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, vector<capnp::DynamicValue::Reader> test, double timestamp, bool show_deprecated);
+  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root, bool show_deprecated);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp);
 };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -30,5 +30,5 @@ public:
   bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp);
-  bool show_deprecated;
+  bool show_deprecated = std::getenv("SHOW_DEPRECATED");
 };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -20,15 +20,14 @@ private:
   std::string dbc_name;
   std::unordered_map<uint8_t, std::shared_ptr<CANParser>> parsers;
   std::shared_ptr<CANPacker> packer;
+  bool show_deprecated = std::getenv("SHOW_DEPRECATED");
 public:
   RlogMessageParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data):
     MessageParser(topic_name, plot_data) { };
 
   bool loadDBC(std::string dbc_str);
-
   bool parseMessageCereal(capnp::DynamicStruct::Reader event);
   bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp);
-  bool show_deprecated = std::getenv("SHOW_DEPRECATED");
 };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -26,7 +26,7 @@ public:
 
   bool loadDBC(std::string dbc_str);
 
-  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool show_deprecated);
+  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, vector<capnp::DynamicValue::Reader> test, double timestamp, bool show_deprecated);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp);
 };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -20,9 +20,8 @@ private:
   std::string dbc_name;
   std::unordered_map<uint8_t, std::shared_ptr<CANParser>> parsers;
   std::shared_ptr<CANPacker> packer;
-  bool show_deprecated;
 public:
-  RlogMessageParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data, bool show_deprecated):
+  RlogMessageParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data):
     MessageParser(topic_name, plot_data) { };
 
   bool loadDBC(std::string dbc_str);
@@ -31,4 +30,5 @@ public:
   bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp);
+  bool show_deprecated;
 };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -26,7 +26,7 @@ public:
 
   bool loadDBC(std::string dbc_str);
 
-  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, capnp::DynamicStruct::Reader event, double timestamp, bool is_root, bool show_deprecated);
+  bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root, bool show_deprecated);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp);
 };

--- a/plugins/DataStreamCereal/datastream_cereal.cpp
+++ b/plugins/DataStreamCereal/datastream_cereal.cpp
@@ -48,7 +48,6 @@ bool DataStreamCereal::start(QStringList*)
 
   QString address;
   StreamCerealDialog* dialog = new StreamCerealDialog();
-  parser.show_deprecated = std::getenv("SHOW_DEPRECATED");
   if (std::getenv("ZMQ"))
   {
     qDebug() << "Using ZMQ backend!";

--- a/plugins/DataStreamCereal/datastream_cereal.cpp
+++ b/plugins/DataStreamCereal/datastream_cereal.cpp
@@ -30,7 +30,7 @@ StreamCerealDialog::~StreamCerealDialog()
 
 DataStreamCereal::DataStreamCereal():
   _running(false),
-  parser(RlogMessageParser("", dataMap(), std::getenv("SHOW_DEPRECATED")))
+  parser(RlogMessageParser("", dataMap()))
 {
 }
 
@@ -48,6 +48,7 @@ bool DataStreamCereal::start(QStringList*)
 
   QString address;
   StreamCerealDialog* dialog = new StreamCerealDialog();
+  parser.show_deprecated = std::getenv("SHOW_DEPRECATED");
   if (std::getenv("ZMQ"))
   {
     qDebug() << "Using ZMQ backend!";


### PR DESCRIPTION
Adds all root fields in Event struct to all nested structs recursively. 

- [x] Create list of non union structs and when is_root, check each field if in non union struct list, to add it to each substruct with `event_` prefix.

Fixes #4 

Also fixes root structs showing when show_deprecated wasn't set