### PR TITLE
Revert building with Qt5.9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,41 +3,18 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
-  cmake \
+  cmake \  
+  qtbase5-dev \
+  libqt5svg5-dev \
+  libqt5websockets5-dev \
+  libqt5opengl5-dev \
+  libqt5x11extras5-dev \
   libbfd-dev \
   libdwarf-dev \
   libdw-dev \
+  libbz2-dev \
+  libcapnp-dev \
   python3 \
-  python3-pip \
-  wget \
-  software-properties-common
-
-RUN cd /tmp && \
-    VERSION=0.7.0 && \
-    wget --no-check-certificate https://capnproto.org/capnproto-c++-${VERSION}.tar.gz && \
-    tar xvf capnproto-c++-${VERSION}.tar.gz && \
-    cd capnproto-c++-${VERSION} && \
-    CXXFLAGS="-fPIC" ./configure && \
-    make -j$(nproc) && \
-    make install
-
-RUN cd /tmp && \
-    wget --no-check-certificate ftp://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz && \
-    tar xvfz bzip2-1.0.8.tar.gz && \
-    cd bzip2-1.0.8 && \
-    CFLAGS="-fPIC" make -f Makefile-libbz2_so && \
-    make && \
-    make install
-
+  python3-pip
 RUN pip3 install jinja2
 ENV PYTHONPATH /tmp/plotjuggler/3rdparty
-
-RUN add-apt-repository "deb http://archive.ubuntu.com/ubuntu bionic main restricted" && \
-    add-apt-repository "deb http://archive.ubuntu.com/ubuntu bionic universe" && \
-    apt-get update && apt-get install -y --no-install-recommends -t bionic \
-    qt5-default \
-    qtbase5-dev \
-    libqt5svg5-dev \
-    libqt5websockets5-dev \
-    libqt5opengl5-dev \
-    libqt5x11extras5-dev

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 docker build -f Dockerfile -t plotjuggler:latest .
 

--- a/plugins/DataLoadRlog/CMakeLists.txt
+++ b/plugins/DataLoadRlog/CMakeLists.txt
@@ -15,8 +15,6 @@ SET(SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/opendbc/can/parser.cc
 )
 
-add_definitions(-L /usr/local/lib)
-
 add_custom_target(
   compile_dbcs ALL
 )
@@ -40,10 +38,10 @@ add_dependencies(DataLoadRlog compile_dbcs  )
 target_link_libraries(DataLoadRlog
   ${Qt5Widgets_LIBRARIES}
   ${Qt5Xml_LIBRARIES}
-  bz2.a
-  capnpc.a
-  capnp.a
-  kj.a
+  -lcapnp
+  -lcapnpc
+  -lbz2
+  -lkj
   plotjuggler_plugin_base)
 
 install(TARGETS DataLoadRlog DESTINATION bin  )


### PR DESCRIPTION
CAN commits didn't nearly change the speed, but this makes it take more than twice as long to parse the logs for some reason. I'll need to look into what specifically causes this.

Before reverting: 12598.1 ms, after reverting: 5580.17 ms for 100,000 event structs