### PR TITLE
Use default timeout of 100 ms

### DIFF
--- a/plugins/DataStreamCereal/datastream_cereal.cpp
+++ b/plugins/DataStreamCereal/datastream_cereal.cpp
@@ -80,7 +80,6 @@ bool DataStreamCereal::start(QStringList*)
     SubSocket *socket;
     socket = SubSocket::create(c, std::string(serv.name), address.toStdString(), false, true);  // don't conflate
     assert(socket != 0);
-    socket->setTimeout(STD_TIMEOUT);
 
     poller->registerSocket(socket);
     sockets.push_back(socket);

--- a/plugins/DataStreamCereal/datastream_cereal.cpp
+++ b/plugins/DataStreamCereal/datastream_cereal.cpp
@@ -132,7 +132,6 @@ void DataStreamCereal::receiveLoop()
 
   while (_running)
   {
-    qDebug() << "main loop";
     // timer.start();
     for (auto sock : poller->poll(100))
     {

--- a/plugins/DataStreamCereal/datastream_cereal.cpp
+++ b/plugins/DataStreamCereal/datastream_cereal.cpp
@@ -132,8 +132,9 @@ void DataStreamCereal::receiveLoop()
 
   while (_running)
   {
+    qDebug() << "main loop";
     // timer.start();
-    for (auto sock : poller->poll(-1))
+    for (auto sock : poller->poll(100))
     {
       while (_running)  // drain socket
       {

--- a/plugins/DataStreamCereal/datastream_cereal.cpp
+++ b/plugins/DataStreamCereal/datastream_cereal.cpp
@@ -10,6 +10,7 @@
 #include "datastream_cereal.h"
 #include "ui_datastream_cereal.h"
 
+#define STD_TIMEOUT 100
 
 StreamCerealDialog::StreamCerealDialog(QWidget *parent) :
   QDialog(parent),
@@ -79,6 +80,7 @@ bool DataStreamCereal::start(QStringList*)
     SubSocket *socket;
     socket = SubSocket::create(c, std::string(serv.name), address.toStdString(), false, true);  // don't conflate
     assert(socket != 0);
+    socket->setTimeout(STD_TIMEOUT);
 
     poller->registerSocket(socket);
     sockets.push_back(socket);
@@ -133,7 +135,7 @@ void DataStreamCereal::receiveLoop()
   while (_running)
   {
     // timer.start();
-    for (auto sock : poller->poll(100))
+    for (auto sock : poller->poll(STD_TIMEOUT))
     {
       while (_running)  // drain socket
       {

--- a/plugins/DataStreamCereal/datastream_cereal.cpp
+++ b/plugins/DataStreamCereal/datastream_cereal.cpp
@@ -10,7 +10,6 @@
 #include "datastream_cereal.h"
 #include "ui_datastream_cereal.h"
 
-#define STD_TIMEOUT 100
 
 StreamCerealDialog::StreamCerealDialog(QWidget *parent) :
   QDialog(parent),
@@ -134,7 +133,7 @@ void DataStreamCereal::receiveLoop()
   while (_running)
   {
     // timer.start();
-    for (auto sock : poller->poll(STD_TIMEOUT))
+    for (auto sock : poller->poll(100))
     {
       while (_running)  // drain socket
       {


### PR DESCRIPTION
In msgq.cc, if timeout specified is `-1` it uses 100 ms as the polling timeout, but it doesn't exit until it gets a message. If we set a timeout of 100 ms, it will still poll for the same amount of time, but not run forever.

https://github.com/commaai/cereal/blob/master/messaging/msgq.cc#L448

Fixes #21 