### PR TITLE
Abstract dbc dialog away into Rlog Parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,9 +250,9 @@ if(Rlog_FOUND)
     add_subdirectory( plugins/DataLoadRlog )
 endif()
 
-# if(Cereal_FOUND)  # TODO: uncomment
-#     add_subdirectory( plugins/DataStreamCereal )
-# endif()
+if(Cereal_FOUND)
+    add_subdirectory( plugins/DataStreamCereal )
+endif()
 
 add_subdirectory( src )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,9 +250,9 @@ if(Rlog_FOUND)
     add_subdirectory( plugins/DataLoadRlog )
 endif()
 
-if(Cereal_FOUND)
-    add_subdirectory( plugins/DataStreamCereal )
-endif()
+# if(Cereal_FOUND)  # TODO: uncomment
+#     add_subdirectory( plugins/DataStreamCereal )
+# endif()
 
 add_subdirectory( src )
 

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -114,9 +114,9 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
           dbc_name = std::getenv("DBC_NAME");
         }
         else {
-          dbc_name = SelectDBCDialog();
+          dbc_name = parser.SelectDBCDialog();
         }
-        if (!dbc_name.empty()) {
+        if (!dbc_name.empty()) {  // todo: move all this logic to the Rlog parser
           if (!parser.loadDBC(dbc_name)) {
             qDebug() << "Could not load specified DBC file";
           }
@@ -142,21 +142,6 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
 
   qDebug() << "Done reading Rlog data"; // unit tests rely on this signal
   return true;
-}
-
-std::string DataLoadRlog::SelectDBCDialog() {
-  QStringList dbc_items;
-  dbc_items.append("");
-  for (auto dbc : get_dbcs()) {
-    dbc_items.append(dbc->name);
-  }
-  bool dbc_selected;
-  QString selected_str = QInputDialog::getItem(
-    nullptr, tr("Select DBC"), tr("Parse CAN using DBC:"), dbc_items, 0, false, &dbc_selected);
-  if (dbc_selected && !selected_str.isEmpty()) {
-    return selected_str.toStdString();
-  }
-  return "";
 }
 
 bool DataLoadRlog::xmlSaveState(QDomDocument& doc, QDomElement& parent_element) const

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -120,7 +120,7 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
     QApplication::processEvents();
     if(progress_dialog.wasCanceled())
     {
-      return false;
+      return true;  // display what we've already parsed
     }
   }
 

--- a/plugins/DataLoadRlog/dataload_rlog.cpp
+++ b/plugins/DataLoadRlog/dataload_rlog.cpp
@@ -108,22 +108,6 @@ bool DataLoadRlog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
 
       capnp::DynamicStruct::Reader event = tmsg->getRoot<capnp::DynamicStruct>(event_struct_schema);
 
-      if (!can_dialog_tried && (event.has("can") || event.has("sendcan"))) {
-        std::string dbc_name;
-        if (std::getenv("DBC_NAME") != nullptr) {
-          dbc_name = std::getenv("DBC_NAME");
-        }
-        else {
-          dbc_name = parser.SelectDBCDialog();
-        }
-        if (!dbc_name.empty()) {  // todo: move all this logic to the Rlog parser
-          if (!parser.loadDBC(dbc_name)) {
-            qDebug() << "Could not load specified DBC file";
-          }
-        }
-        can_dialog_tried = true;
-      }
-
       parser.parseMessageCereal(event);
     }
     catch (const kj::Exception& e)

--- a/plugins/DataLoadRlog/dataload_rlog.hpp
+++ b/plugins/DataLoadRlog/dataload_rlog.hpp
@@ -1,10 +1,10 @@
 #pragma once
-#include <bzlib.h>
 #include <iostream>
 #include <pwd.h>
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <bzlib.h>
 #include <capnp/schema-parser.h>
 #include <capnp/serialize-packed.h>
 #include <PlotJuggler/dataloader_base.h>

--- a/plugins/DataLoadRlog/dataload_rlog.hpp
+++ b/plugins/DataLoadRlog/dataload_rlog.hpp
@@ -1,17 +1,17 @@
 #pragma once
-
-#include <QProgressDialog>
-#include <QComboBox>
-#include <QDir>
+#include <bzlib.h>
+#include <capnp/schema-parser.h>
+#include <capnp/serialize-packed.h>
+#include <PlotJuggler/dataloader_base.h>
+#include <pwd.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <iostream>
-#include <unistd.h>
-#include <sys/types.h>
-#include <pwd.h>
-#include <bzlib.h>
-#include <PlotJuggler/dataloader_base.h>
-#include <capnp/serialize-packed.h>
-#include <capnp/schema-parser.h>
+#include <QComboBox>
+#include <QDir>
+#include <QProgressDialog>
+
 #include <rlog_parser.hpp>
 
 using namespace PJ;

--- a/plugins/DataLoadRlog/dataload_rlog.hpp
+++ b/plugins/DataLoadRlog/dataload_rlog.hpp
@@ -2,7 +2,6 @@
 
 #include <QProgressDialog>
 #include <QComboBox>
-#include <QInputDialog>
 #include <QDir>
 
 #include <iostream>
@@ -31,8 +30,6 @@ public:
   virtual const char* name() const override { return "DataLoad Rlog"; }
   virtual bool xmlSaveState(QDomDocument& doc, QDomElement& parent_element) const override;
   virtual bool xmlLoadState(const QDomElement& parent_element) override;
-
-  std::string SelectDBCDialog();
 
 private:
   std::vector<const char*> _extensions;

--- a/plugins/DataLoadRlog/dataload_rlog.hpp
+++ b/plugins/DataLoadRlog/dataload_rlog.hpp
@@ -34,5 +34,4 @@ public:
 private:
   std::vector<const char*> _extensions;
   std::string _default_time_axis;
-  bool can_dialog_tried = false;
 };

--- a/plugins/DataLoadRlog/dataload_rlog.hpp
+++ b/plugins/DataLoadRlog/dataload_rlog.hpp
@@ -1,13 +1,13 @@
 #pragma once
 #include <bzlib.h>
-#include <capnp/schema-parser.h>
-#include <capnp/serialize-packed.h>
-#include <PlotJuggler/dataloader_base.h>
+#include <iostream>
 #include <pwd.h>
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <iostream>
+#include <capnp/schema-parser.h>
+#include <capnp/serialize-packed.h>
+#include <PlotJuggler/dataloader_base.h>
 #include <QComboBox>
 #include <QDir>
 #include <QProgressDialog>

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -26,7 +26,7 @@ bool RlogMessageParser::loadDBC(std::string dbc_str)
 bool RlogMessageParser::parseMessageCereal(capnp::DynamicStruct::Reader event)
 {
   if (can_dialog_needed && (event.has("can") || event.has("sendcan"))) {
-    selectDBCDialog();
+    selectDBCDialog();  // prompts for and loads DBC
   }
 
   double time_stamp = (double)event.get("logMonoTime").as<uint64_t>() / 1e9;

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -151,3 +151,18 @@ bool RlogMessageParser::parseCanMessage(
   }
   return true;
 }
+
+std::string RlogMessageParser::SelectDBCDialog() {
+  QStringList dbc_items;
+  dbc_items.append("");
+  for (auto dbc : get_dbcs()) {
+    dbc_items.append(dbc->name);
+  }
+  bool dbc_selected;
+  QString selected_str = QInputDialog::getItem(
+    nullptr, QObject::tr("Select DBC"), QObject::tr("Parse CAN using DBC:"), dbc_items, 0, false, &dbc_selected);
+  if (dbc_selected && !selected_str.isEmpty()) {
+    return selected_str.toStdString();
+  }
+  return "";
+}

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -3,9 +3,7 @@
 
 void RlogMessageParser::initParser()
 {
-  qDebug() << "on init!";
   show_deprecated = std::getenv("SHOW_DEPRECATED");
-
   if (std::getenv("DBC_NAME") != nullptr)
   {
     can_dialog_needed = !loadDBC(std::getenv("DBC_NAME"));

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -1,7 +1,8 @@
 #include "rlog_parser.hpp"
 
 
-void RlogMessageParser::initParser()
+RlogMessageParser::RlogMessageParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data) :
+  MessageParser(topic_name, plot_data)
 {
   show_deprecated = std::getenv("SHOW_DEPRECATED");
   if (std::getenv("DBC_NAME") != nullptr)

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -14,7 +14,7 @@ void RlogMessageParser::initParser()
   }
 }
 
-bool RlogMessageParser::loadDBC(std::string dbc_str)  // TODO: remove
+bool RlogMessageParser::loadDBC(std::string dbc_str)
 {
   if (!dbc_str.empty())
   {
@@ -26,7 +26,7 @@ bool RlogMessageParser::loadDBC(std::string dbc_str)  // TODO: remove
     dbc_name = dbc_str;  // is used later to instantiate CANParser
     packer = std::make_shared<CANPacker>(dbc_str);
   }
-  qDebug() << "loaded DBC successfully!" << dbc_str.c_str();  // TODO: temp
+  qDebug() << "Loaded DBC:" << dbc_str.c_str();
   return true;
 }
 
@@ -42,13 +42,11 @@ bool RlogMessageParser::parseMessageCereal(capnp::DynamicStruct::Reader event)
     can_dialog_needed = false;  // no way to verify selected dbc is correct, so don't ask again
     has_can = true;
   }
-//  qDebug() << "has can:" << !can_dialog_needed << (event.has("can") || event.has("sendcan"));
 
   double time_stamp = (double)event.get("logMonoTime").as<uint64_t>() / 1e9;
-  // if can_dialog_needed is true, then we haven't seen a can message
-  if (!can_dialog_needed && event.has("can")) {
+  if (event.has("can")) {
     return parseCanMessage("/can", event.get("can").as<capnp::DynamicList>(), time_stamp);
-  } else if (!can_dialog_needed && event.has("sendcan")) {
+  } else if (event.has("sendcan")) {
     return parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp);
   } else {
     return parseMessageImpl("", event, time_stamp, true);

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -22,9 +22,9 @@ bool RlogMessageParser::loadDBC(std::string dbc_str)
       return false;
     }
     dbc_name = dbc_str;  // is used later to instantiate CANParser
-    packer = std::make_shared<CANPacker>(dbc_str);
+    packer = std::make_shared<CANPacker>(dbc_name);
   }
-  qDebug() << "Loaded DBC:" << dbc_str.c_str();
+  qDebug() << "Loaded DBC:" << dbc_name.c_str();
   return true;
 }
 
@@ -33,10 +33,18 @@ bool RlogMessageParser::parseMessage(const MessageRef msg, double time_stamp)
   return false;
 }
 
+void RlogMessageParser::showDBCDialog()
+{
+  if (can_dialog_needed)
+  {
+    can_dialog_needed = !loadDBC(SelectDBCDialog());
+  }
+}
+
 bool RlogMessageParser::parseMessageCereal(capnp::DynamicStruct::Reader event)
 {
   if (can_dialog_needed && (event.has("can") || event.has("sendcan"))) {
-    can_dialog_needed = !loadDBC(SelectDBCDialog());
+    showDBCDialog();
   }
 
   double time_stamp = (double)event.get("logMonoTime").as<uint64_t>() / 1e9;

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -9,25 +9,24 @@ void RlogMessageParser::initParser()
 
   if (std::getenv("DBC_NAME") != nullptr)
   {
-    dbc_name = std::getenv("DBC_NAME");
-    can_dialog_needed = !loadDBC(dbc_name);
+    can_dialog_needed = !loadDBC(std::getenv("DBC_NAME"));
     has_can = true;
   }
 }
 
 bool RlogMessageParser::loadDBC(std::string dbc_str)  // TODO: remove
 {
-  if (!dbc_name.empty())
+  if (!dbc_str.empty())
   {
-    if (dbc_lookup(dbc_name) == nullptr)
+    if (dbc_lookup(dbc_str) == nullptr)
     {
-      qDebug() << "Could not load specified DBC file:" << dbc_name.c_str();
+      qDebug() << "Could not load specified DBC file:" << dbc_str.c_str();
       return false;
     }
     dbc_name = dbc_str;  // is used later to instantiate CANParser
-    packer = std::make_shared<CANPacker>(dbc_name);
+    packer = std::make_shared<CANPacker>(dbc_str);
   }
-  qDebug() << "loaded DBC successfully!" << dbc_name.c_str();  // TODO: temp
+  qDebug() << "loaded DBC successfully!" << dbc_str.c_str();  // TODO: temp
   return true;
 }
 
@@ -39,7 +38,7 @@ bool RlogMessageParser::parseMessage(const MessageRef msg, double time_stamp)
 bool RlogMessageParser::parseMessageCereal(capnp::DynamicStruct::Reader event)
 {
   if (can_dialog_needed && (event.has("can") || event.has("sendcan"))) {
-    dbc_name = SelectDBCDialog();
+    loadDBC(SelectDBCDialog());
     can_dialog_needed = false;  // no way to verify selected dbc is correct, so don't ask again
     has_can = true;
   }

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -12,22 +12,13 @@ void RlogMessageParser::initParser()
 
 bool RlogMessageParser::loadDBC(std::string dbc_str)
 {
-  if (!dbc_str.empty())
-  {
-    if (dbc_lookup(dbc_str) == nullptr)
-    {
-      qDebug() << "Could not load specified DBC file:" << dbc_str.c_str();
-      return false;
-    }
+  if (!dbc_str.empty() && dbc_lookup(dbc_str) != nullptr) {
     dbc_name = dbc_str;  // is used later to instantiate CANParser
     packer = std::make_shared<CANPacker>(dbc_name);
+    qDebug() << "Loaded DBC:" << dbc_name.c_str();
+    return true;
   }
-  qDebug() << "Loaded DBC:" << dbc_name.c_str();
-  return true;
-}
-
-bool RlogMessageParser::parseMessage(const MessageRef msg, double time_stamp)
-{
+  qDebug() << "Could not load specified DBC file:" << dbc_str.c_str();
   return false;
 }
 

--- a/plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plugins/DataLoadRlog/rlog_parser.cpp
@@ -5,12 +5,10 @@ void RlogMessageParser::initParser()
 {
   qDebug() << "on init!";
   show_deprecated = std::getenv("SHOW_DEPRECATED");
-  has_can = false;
 
   if (std::getenv("DBC_NAME") != nullptr)
   {
     can_dialog_needed = !loadDBC(std::getenv("DBC_NAME"));
-    has_can = true;
   }
 }
 
@@ -38,9 +36,7 @@ bool RlogMessageParser::parseMessage(const MessageRef msg, double time_stamp)
 bool RlogMessageParser::parseMessageCereal(capnp::DynamicStruct::Reader event)
 {
   if (can_dialog_needed && (event.has("can") || event.has("sendcan"))) {
-    loadDBC(SelectDBCDialog());
-    can_dialog_needed = false;  // no way to verify selected dbc is correct, so don't ask again
-    has_can = true;
+    can_dialog_needed = !loadDBC(SelectDBCDialog());
   }
 
   double time_stamp = (double)event.get("logMonoTime").as<uint64_t>() / 1e9;

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -1,7 +1,4 @@
 #pragma once
-#include <capnp/dynamic.h>
-#include <capnp/schema.h>
-#include <capnp/serialize.h>
 #include <PlotJuggler/messageparser_base.h>
 
 #include <QInputDialog>

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -24,7 +24,6 @@ private:
   void initParser();
   bool show_deprecated;
   bool can_dialog_needed = true;
-  bool has_can = false;
 public:
   RlogMessageParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data):
     MessageParser(topic_name, plot_data) { initParser(); };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -5,6 +5,7 @@
 #include <capnp/schema.h>
 #include <capnp/serialize.h>
 #include <iostream>
+#include <QInputDialog>
 
 #ifndef DYNAMIC_CAPNP
 #define DYNAMIC_CAPNP  // Do not depend on generated log.capnp.h structure
@@ -25,6 +26,7 @@ public:
   RlogMessageParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data):
     MessageParser(topic_name, plot_data) { };
 
+  std::string SelectDBCDialog();
   bool loadDBC(std::string dbc_str);
   bool parseMessageCereal(capnp::DynamicStruct::Reader event);
   bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root);

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -19,12 +19,10 @@ private:
   std::shared_ptr<CANPacker> packer;
   std::string SelectDBCDialog();
   bool loadDBC(std::string dbc_str);
-  void initParser();
   bool show_deprecated;
   bool can_dialog_needed = true;
 public:
-  RlogMessageParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data):
-    MessageParser(topic_name, plot_data) { initParser(); };
+  RlogMessageParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data);
 
   bool parseMessageCereal(capnp::DynamicStruct::Reader event);
   bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root);

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -1,15 +1,15 @@
 #pragma once
-
-#include <PlotJuggler/messageparser_base.h>
 #include <capnp/dynamic.h>
 #include <capnp/schema.h>
 #include <capnp/serialize.h>
-#include <iostream>
+#include <PlotJuggler/messageparser_base.h>
+
 #include <QInputDialog>
 
 #ifndef DYNAMIC_CAPNP
 #define DYNAMIC_CAPNP  // Do not depend on generated log.capnp.h structure
 #endif
+
 #include "common.h"
 #include "common_dbc.h"
 

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -33,6 +33,6 @@ public:
   bool parseMessageCereal(capnp::DynamicStruct::Reader event);
   bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
-  bool parseMessage(const MessageRef serialized_msg, double timestamp);
+  bool parseMessage(const MessageRef serialized_msg, double timestamp) { return false; };  // not implemented
   void showDBCDialog();
 };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -17,7 +17,6 @@ private:
   std::string dbc_name;
   std::unordered_map<uint8_t, std::shared_ptr<CANParser>> parsers;
   std::shared_ptr<CANPacker> packer;
-  std::string SelectDBCDialog();
   bool loadDBC(std::string dbc_str);
   bool show_deprecated;
   bool can_dialog_needed = true;
@@ -28,5 +27,5 @@ public:
   bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp) { return false; };  // not implemented
-  void showDBCDialog();
+  void selectDBCDialog();
 };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -21,6 +21,8 @@ private:
   std::string dbc_name;
   std::unordered_map<uint8_t, std::shared_ptr<CANParser>> parsers;
   std::shared_ptr<CANPacker> packer;
+  std::string SelectDBCDialog();
+  bool loadDBC(std::string dbc_str);
   void initParser();
   bool show_deprecated;
   bool can_dialog_needed = true;
@@ -28,10 +30,9 @@ public:
   RlogMessageParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data):
     MessageParser(topic_name, plot_data) { initParser(); };
 
-  std::string SelectDBCDialog();
-  bool loadDBC(std::string dbc_str);
   bool parseMessageCereal(capnp::DynamicStruct::Reader event);
   bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root);
   bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
   bool parseMessage(const MessageRef serialized_msg, double timestamp);
+  void showDBCDialog();
 };

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <PlotJuggler/messageparser_base.h>
-
 #include <QInputDialog>
 
 #ifndef DYNAMIC_CAPNP

--- a/plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plugins/DataLoadRlog/rlog_parser.hpp
@@ -21,10 +21,13 @@ private:
   std::string dbc_name;
   std::unordered_map<uint8_t, std::shared_ptr<CANParser>> parsers;
   std::shared_ptr<CANPacker> packer;
-  bool show_deprecated = std::getenv("SHOW_DEPRECATED");
+  void initParser();
+  bool show_deprecated;
+  bool can_dialog_needed = true;
+  bool has_can = false;
 public:
   RlogMessageParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data):
-    MessageParser(topic_name, plot_data) { };
+    MessageParser(topic_name, plot_data) { initParser(); };
 
   std::string SelectDBCDialog();
   bool loadDBC(std::string dbc_str);

--- a/plugins/DataStreamCereal/datastream_cereal.cpp
+++ b/plugins/DataStreamCereal/datastream_cereal.cpp
@@ -84,7 +84,7 @@ bool DataStreamCereal::start(QStringList*)
     sockets.push_back(socket);
   }
 
-  parser.showDBCDialog();  // can't show dialog in a thread so show it now
+  parser.selectDBCDialog();  // can't show dialog in a thread so show it now
   _running = true;
   _receive_thread = std::thread(&DataStreamCereal::receiveLoop, this);
 

--- a/plugins/DataStreamCereal/datastream_cereal.cpp
+++ b/plugins/DataStreamCereal/datastream_cereal.cpp
@@ -2,7 +2,7 @@
 
 #include <QDebug>
 #include <QDialog>
-#include <QElapsedTimer>
+//#include <QElapsedTimer>
 #include <QIntValidator>
 #include <QMessageBox>
 #include <QSettings>
@@ -84,23 +84,7 @@ bool DataStreamCereal::start(QStringList*)
     sockets.push_back(socket);
   }
 
-  // Now get DBC name for CAN parsing
-  // TODO: use an env var to enable can parsing
-  std::string dbc_name;
-  qDebug() << "here1";
-  if (std::getenv("DBC_NAME") != nullptr) {
-    qDebug() << "here";
-    dbc_name = std::getenv("DBC_NAME");
-  } else {
-    dbc_name = parser.SelectDBCDialog();
-  }
-
-  if (!dbc_name.empty()) {
-    if (!parser.loadDBC(dbc_name)) {
-      qDebug() << "Could not load specified DBC file:" << dbc_name.c_str();
-    }
-  }
-
+  parser.showDBCDialog();  // can't show dialog in a thread
   _running = true;
   _receive_thread = std::thread(&DataStreamCereal::receiveLoop, this);
 

--- a/plugins/DataStreamCereal/datastream_cereal.cpp
+++ b/plugins/DataStreamCereal/datastream_cereal.cpp
@@ -84,7 +84,7 @@ bool DataStreamCereal::start(QStringList*)
     sockets.push_back(socket);
   }
 
-  parser.showDBCDialog();  // can't show dialog in a thread
+  parser.showDBCDialog();  // can't show dialog in a thread so show it now
   _running = true;
   _receive_thread = std::thread(&DataStreamCereal::receiveLoop, this);
 

--- a/plugins/DataStreamCereal/datastream_cereal.cpp
+++ b/plugins/DataStreamCereal/datastream_cereal.cpp
@@ -84,6 +84,23 @@ bool DataStreamCereal::start(QStringList*)
     sockets.push_back(socket);
   }
 
+  // Now get DBC name for CAN parsing
+  // TODO: use an env var to enable can parsing
+  std::string dbc_name;
+  qDebug() << "here1";
+  if (std::getenv("DBC_NAME") != nullptr) {
+    qDebug() << "here";
+    dbc_name = std::getenv("DBC_NAME");
+  } else {
+    dbc_name = parser.SelectDBCDialog();
+  }
+
+  if (!dbc_name.empty()) {
+    if (!parser.loadDBC(dbc_name)) {
+      qDebug() << "Could not load specified DBC file:" << dbc_name.c_str();
+    }
+  }
+
   _running = true;
   _receive_thread = std::thread(&DataStreamCereal::receiveLoop, this);
 
@@ -116,17 +133,6 @@ void DataStreamCereal::shutdown()
 
 void DataStreamCereal::receiveLoop()
 {
-  std::string dbc_name;
-  if (std::getenv("DBC_NAME") != nullptr) {
-    dbc_name = std::getenv("DBC_NAME");
-  }
-
-  if (!dbc_name.empty()) {
-    if (!parser.loadDBC(dbc_name)) {
-      qDebug() << "Could not load specified DBC file:" << dbc_name.c_str();
-    }
-  }
-
   AlignedBuffer aligned_buf;
   // QElapsedTimer timer;
 


### PR DESCRIPTION
Rlog Parser:
- [x] Automatically detect DBC name from rlogs and load it in (when passing `--can` to juggle.py). No user intervention required. If it can't load the DBC from the var, or no var exists it will prompt the user to enter a DBC.

Cereal Streamer:
- [x] If an environment variable holding the name of the DBC is not found (same as above, `DBC_NAME`), show DBC selection dialog on plugin start.
