### PR TITLE
rlog plugin: fix CAN data on wrong buses 

### DIFF
--- a/plotjuggler_plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plotjuggler_plugins/DataLoadRlog/rlog_parser.cpp
@@ -170,7 +170,6 @@ bool RlogMessageParser::parseCanMessage(
   if (dbc_name.empty()) {
     return false;
   }
-
   std::set<uint8_t> updated_busses;
   for(auto elem : listValue) {
     auto value = elem.as<capnp::DynamicStruct>();

--- a/plotjuggler_plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plotjuggler_plugins/DataLoadRlog/rlog_parser.cpp
@@ -58,11 +58,12 @@ bool RlogMessageParser::parseMessageCereal(capnp::DynamicStruct::Reader event)
     selectDBCDialog();  // prompts for and loads DBC
   }
 
-  double time_stamp = (double)event.get("logMonoTime").as<uint64_t>() / 1e9;
+  uint64_t last_sec = event.get("logMonoTime").as<uint64_t>();
+  double time_stamp = (double)last_sec / 1e9;
   if (event.has("can")) {
-    return parseCanMessage("/can", event.get("can").as<capnp::DynamicList>(), time_stamp, event.get("logMonoTime").as<uint64_t>());
+    return parseCanMessage("/can", event.get("can").as<capnp::DynamicList>(), time_stamp, last_sec);
   } else if (event.has("sendcan")) {
-    return parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp, event.get("logMonoTime").as<uint64_t>());
+    return parseCanMessage("/sendcan", event.get("sendcan").as<capnp::DynamicList>(), time_stamp, last_sec);
   } else {
     return parseMessageImpl("", event, time_stamp, true);
   }
@@ -164,11 +165,12 @@ bool RlogMessageParser::parseMessageImpl(const std::string& topic_name, capnp::D
 }
 
 bool RlogMessageParser::parseCanMessage(
-  const std::string& topic_name, capnp::DynamicList::Reader listValue, double time_stamp, uint64_t _log_mono_time)
+  const std::string& topic_name, capnp::DynamicList::Reader listValue, double time_stamp, uint64_t last_sec)
 {
   if (dbc_name.empty()) {
     return false;
   }
+
   // TODO: see if the way parser.cc does it is faster or not
   std::set<uint8_t> updated_busses;
   for(auto elem : listValue) {
@@ -180,21 +182,16 @@ bool RlogMessageParser::parseCanMessage(
     }
 
     updated_busses.insert(bus);
-    parsers[bus]->UpdateCans(_log_mono_time, value);
+    parsers[bus]->UpdateCans(last_sec, value);
   }
   for (uint8_t bus : updated_busses) {
-    // TODO: use true monologtime
-    parsers[bus]->last_sec = _log_mono_time;
+    parsers[bus]->last_sec = last_sec;
     for (auto& sg : parsers[bus]->query_latest()) {
-      // TODO: use all values
-      // qDebug() << sg.all_values;
+      // TODO: plot all updated values
       PJ::PlotData& _data_series = getSeries(topic_name + '/' + std::to_string(bus) + '/' +
           packer->lookup_message(sg.address)->name + '/' + sg.name);
       _data_series.pushBack({time_stamp, (double)sg.value});
     }
-//    qDebug() << time_stamp;
-//    qDebug() << time_stamp * 1e9;
-
   }
   return true;
 }

--- a/plotjuggler_plugins/DataLoadRlog/rlog_parser.cpp
+++ b/plotjuggler_plugins/DataLoadRlog/rlog_parser.cpp
@@ -171,7 +171,6 @@ bool RlogMessageParser::parseCanMessage(
     return false;
   }
 
-  // TODO: see if the way parser.cc does it is faster or not
   std::set<uint8_t> updated_busses;
   for(auto elem : listValue) {
     auto value = elem.as<capnp::DynamicStruct>();

--- a/plotjuggler_plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plotjuggler_plugins/DataLoadRlog/rlog_parser.hpp
@@ -19,6 +19,7 @@ class RlogMessageParser : MessageParser
 private:
   std::string dbc_name;
   std::unordered_map<uint8_t, std::shared_ptr<CANParser>> parsers;
+//  std::unordered_map<uint8_t, std::shared_ptr<CANParser>> parsers;
   std::shared_ptr<CANPacker> packer;
   bool loadDBC(std::string dbc_str);
   bool show_deprecated;
@@ -33,7 +34,7 @@ public:
   capnp::StructSchema getSchema();
   bool parseMessageCereal(capnp::DynamicStruct::Reader event);
   bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root);
-  bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp);
+  bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp, uint64_t _log_mono_time);
   bool parseMessage(const MessageRef serialized_msg, double &timestamp) { return false; };  // not implemented
   void selectDBCDialog();
 };

--- a/plotjuggler_plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plotjuggler_plugins/DataLoadRlog/rlog_parser.hpp
@@ -34,7 +34,7 @@ public:
   capnp::StructSchema getSchema();
   bool parseMessageCereal(capnp::DynamicStruct::Reader event);
   bool parseMessageImpl(const std::string& topic_name, capnp::DynamicValue::Reader node, double timestamp, bool is_root);
-  bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp, uint64_t _log_mono_time);
+  bool parseCanMessage(const std::string& topic_name, capnp::DynamicList::Reader node, double timestamp, uint64_t last_sec);
   bool parseMessage(const MessageRef serialized_msg, double &timestamp) { return false; };  // not implemented
   void selectDBCDialog();
 };

--- a/plotjuggler_plugins/DataLoadRlog/rlog_parser.hpp
+++ b/plotjuggler_plugins/DataLoadRlog/rlog_parser.hpp
@@ -19,7 +19,6 @@ class RlogMessageParser : MessageParser
 private:
   std::string dbc_name;
   std::unordered_map<uint8_t, std::shared_ptr<CANParser>> parsers;
-//  std::unordered_map<uint8_t, std::shared_ptr<CANParser>> parsers;
   std::shared_ptr<CANPacker> packer;
   bool loadDBC(std::string dbc_str);
   bool show_deprecated;


### PR DESCRIPTION
Resolves https://github.com/commaai/PlotJuggler/issues/39 and https://github.com/commaai/openpilot/issues/23340

- Update CANParser's `last_sec` variable before querying for signals, as it does if you call update_string
- Give CANParser the real `logMonoTime`, not seconds as a double that's casted to an unsigned int, may fix some timing issues.

How it used to behave was CAN data wasn't added to the timeseries/returned by `query_latest` until its message *wasn't* updated this cycle. So messages not updated would show up (on possibly wrong buses, and across can/sendcan), and updated messages would not (until they weren't).

Fixed by updating `last_sec` *before* querying latest messages like CANParser assumes it is, not after.

Here's an example of a Toyota route where `ACC_CONTROL` shows up on bus 0 (when it should only exist on bus 2 and 128) with jumps. https://user-images.githubusercontent.com/25857203/154433406-0dbe3008-22c6-4c5d-9e48-e5327db134c8.png.

Messages that show up on `sendcan` before and after: https://imgur.com/a/1YXpbxp