### PR TITLE
Use gnu tar on macOS

### DIFF
--- a/.github/workflows/openpilot.yaml
+++ b/.github/workflows/openpilot.yaml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 env:
   ZIP: |
     cd $GITHUB_WORKSPACE/build/bin
+    export PATH=/usr/local/opt/gnu-tar/libexec/gnubin:$PATH
     sudo tar -czf $(uname -s)-$(uname -m).tar.gz plotjuggler libDataLoadRlog.* libDataStreamCereal.*
 
 jobs:
@@ -41,7 +42,7 @@ jobs:
         python-version: '3.8.x'
     - name: setup dependencies
       run: |
-        brew install cmake bzip2 capnp qt@5 zeromq protobuf
+        brew install cmake bzip2 capnp qt@5 zeromq protobuf gnu-tar
         sudo pip3 install --no-cache-dir -r 3rdparty/opendbc/requirements.txt
     - name: build
       run: |


### PR DESCRIPTION
This PR fixes exec format error when running plotjuggler binary (downloaded from plotjuggler github release tar.gz) on macOS x86-64. 

Compressing files using macOS system tar corrupts the plotjuggler binary (https://github.com/Homebrew/brew/issues/6539).

repro
```
uname -a
Darwin MBP.local 21.5.0 Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:22 PDT 2022; root:xnu-8020.121.3~4/RELEASE_X86_64 x86_64

./juggle.py --install
./bin/plotjuggler 
zsh: exec format error: ./bin/plotjuggler

file bin/plotjuggler 
bin/plotjuggler: data

sha1sum bin/plotjuggler 
092bc88aaeabd7bf0a83d6708c9dedae896034c5  bin/plotjuggler
```

after installing fixed build from https://github.com/martinl/PlotJuggler/releases:
```
file bin/plotjuggler 
bin/plotjuggler: Mach-O 64-bit executable x86_64

sha1sum bin/plotjuggler 
19aa012c55fd926679278b36ffb23e1b681a10f6  bin/plotjuggler
```